### PR TITLE
Fix typos in status message

### DIFF
--- a/window.py
+++ b/window.py
@@ -327,7 +327,7 @@ def get_answer_from_ai(messages, callback):
             response = requests.post(SERVER_URL, headers=headers, json=data)
 
             if response.status_code == 200:
-                status_label.config(text="Success Get Response Form Server")
+                status_label.config(text="Success Get Response From Server")
                 callback(response.json()["analysis_result"])
             else:
                 print("Failed to get response:", response.status_code, response.text)


### PR DESCRIPTION
## Summary
- update the success message typo in `window.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ed33b0c48331aef12e99fa9a8cd9